### PR TITLE
feat: improve compass reliability and add optional enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+package-lock.json
+yarn.lock
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -35,56 +35,71 @@ cd ios && pod install && cd ..
 ## Usage
 
 ```javascript
-import { useQiblaCompass } from "react-native-qibla-compass";
+import { useQiblaCompass } from 'react-native-qibla-compass';
 
 export default function App() {
-  const {
-    qiblad,
-    compassDirection,
-    compassDegree,
-    compassRotate,
-    kabaRotate,
-    error,
-    isLoading,
-    reinitCompass,
-  } = useQiblaCompass();
+    const {
+        qiblad,
+        compassDirection,
+        compassDegree,
+        compassRotate,
+        kabaRotate,
+        isFacingQibla,
+        error,
+        isLoading,
+        reinitCompass,
+    } = useQiblaCompass();
 
-  // Rest of your code
+    // Rest of your code
 }
+```
+
+The hook accepts an optional options object:
+
+```javascript
+const { ... } = useQiblaCompass({
+  updateInterval: 100, // magnetometer update interval in ms (default 100)
+  smoothingFactor: 0.15, // 0..1 needle smoothing; 0 disables (default 0.15)
+  alignTolerance: 5, // degrees within which `isFacingQibla` is true (default 5)
+});
 ```
 
 or
 
 ```javascript
-import QiblaCompass from "react-native-qibla-compass";
+import QiblaCompass from 'react-native-qibla-compass';
 
 export default function App() {
-  return (
-    <QiblaCompass
-      color={"#123"} // optional
-      backgroundColor={"#fff"} // optional
-      textStyles={{ textAlign: "center", fontSize: 24 }} // optional
-      kaabaImage={require('./assets/kaaba.png')} // optional
-      compassImage={require('./assets/compass.png')} // optional
-    />
-  );
+    return (
+        <QiblaCompass
+            color={'#123'} // optional
+            backgroundColor={'#fff'} // optional
+            textStyles={{ textAlign: 'center', fontSize: 24 }} // optional
+            kaabaImage={require('./assets/kaaba.png')} // optional
+            compassImage={require('./assets/compass.png')} // optional
+            size={300} // optional
+            alignColor={'#2e8b57'} // optional — color shown when facing the Qibla
+            enableHaptics // optional — requires expo-haptics
+            onAligned={() => console.log('Facing the Qibla')} // optional
+        />
+    );
 }
 ```
 
 If you want to reinit qibla compass, you can do it on this way:
 
 ```javascript
-import { useRef } from "react";
-import QiblaCompass from "react-native-qibla-compass";
+import { useRef } from 'react';
+import QiblaCompass from 'react-native-qibla-compass';
 
 export default function App() {
-  const qiblaCompassRef = useRef();
+    const qiblaCompassRef = useRef();
 
-  const reinitCompass = () => {
-    qiblaCompassRef.current.reinitCompass();
-  };
+    const reinitCompass = () => {
+        qiblaCompassRef.current.reinitCompass();
+    };
 
-  return <QiblaCompass ref={qiblaCompassRef} />;
+    return <QiblaCompass ref={qiblaCompassRef} />;
 }
 ```
 
@@ -99,19 +114,29 @@ The `useQiblaCompass` hook returns an object with the following properties:
 - `compassDegree` (number): The compass angle in degrees.
 - `compassRotate` (number): The compass rotation angle in degrees.
 - `kabaRotate` (number): The Kaaba icon rotation angle in degrees.
+- `isFacingQibla` (boolean): `true` when the device is pointing at the Qibla (within `alignTolerance`).
 - `error` (string): An error message, if any.
 - `isLoading` (boolean): Indicates if the compass data is still loading.
 - `reinitCompass` (function): A function to reinitialize the Qibla Compass.
 
 ### `<QiblaCompass />`
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `backgroundColor` | string | `'transparent'` | Background color of the compass container |
-| `color` | string | `'#000'` | Text color |
-| `textStyles` | object | `{}` | Additional text styles |
-| `compassImage` | ImageSource | Built-in image | Custom compass image |
-| `kaabaImage` | ImageSource | Built-in image | Custom Kaaba image |
+| Prop              | Type        | Default         | Description                                                |
+| ----------------- | ----------- | --------------- | ---------------------------------------------------------- |
+| `backgroundColor` | string      | `'transparent'` | Background color of the compass container                  |
+| `color`           | string      | `'#000'`        | Text color                                                 |
+| `textStyles`      | object      | `{}`            | Additional text styles                                     |
+| `compassImage`    | ImageSource | Built-in image  | Custom compass image                                       |
+| `kaabaImage`      | ImageSource | Built-in image  | Custom Kaaba image                                         |
+| `size`            | number      | `300`           | Diameter of the compass dial                               |
+| `updateInterval`  | number      | `100`           | Magnetometer update interval (ms)                          |
+| `smoothingFactor` | number      | `0.15`          | Needle smoothing `0..1`; `0` disables it                   |
+| `alignTolerance`  | number      | `5`             | Degrees within which the device counts as facing the Qibla |
+| `alignColor`      | string      | `'#2e8b57'`     | Qibla text color shown when facing the Qibla               |
+| `enableHaptics`   | bool        | `false`         | Fire a haptic when aligned (requires `expo-haptics`)       |
+| `onAligned`       | function    | —               | Called once each time the device starts facing the Qibla   |
+
+All new props are optional and backwards-compatible — existing usage keeps working unchanged.
 
 ## Permissions
 

--- a/index.js
+++ b/index.js
@@ -5,26 +5,141 @@ import React, {
     useState,
     useEffect,
     useCallback,
+    useRef,
     forwardRef,
     useImperativeHandle,
 } from 'react';
 import { Image, View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { moderateScale } from 'react-native-size-matters';
 
-export const useQiblaCompass = () => {
-    const [subscription, setSubscription] = useState(null);
+const DEFAULT_SIZE = 300;
+const DEFAULT_UPDATE_INTERVAL = 100;
+const DEFAULT_SMOOTHING = 0.15;
+const DEFAULT_ALIGN_TOLERANCE = 5;
+const DEFAULT_ALIGN_COLOR = '#2e8b57';
+
+// Kaaba coordinates (Mecca), in degrees.
+const KAABA_LAT = 21.4225;
+const KAABA_LNG = 39.8264;
+
+// Convert a raw magnetometer reading into a 0..360 angle.
+const computeAngle = (magnetometer) => {
+    if (!magnetometer) {
+        return 0;
+    }
+    const { x, y } = magnetometer;
+    let angle = Math.atan2(y, x);
+    if (angle < 0) {
+        angle += 2 * Math.PI;
+    }
+    return Math.round(angle * (180 / Math.PI));
+};
+
+// Map the device angle to a compass heading (0 = North), wrapped into [0, 360).
+const headingFromAngle = (angle) => (angle + 270) % 360;
+
+// The cardinal/intercardinal name for a heading in degrees.
+const cardinalDirection = (degree) => {
+    if (degree >= 22.5 && degree < 67.5) {
+        return 'NE';
+    } else if (degree >= 67.5 && degree < 112.5) {
+        return 'E';
+    } else if (degree >= 112.5 && degree < 157.5) {
+        return 'SE';
+    } else if (degree >= 157.5 && degree < 202.5) {
+        return 'S';
+    } else if (degree >= 202.5 && degree < 247.5) {
+        return 'SW';
+    } else if (degree >= 247.5 && degree < 292.5) {
+        return 'W';
+    } else if (degree >= 292.5 && degree < 337.5) {
+        return 'NW';
+    }
+    return 'N';
+};
+
+// Great-circle Qibla bearing (from true North) for a given location.
+const calculateQibla = (latitude, longitude) => {
+    const PI = Math.PI;
+    const latk = (KAABA_LAT * PI) / 180.0;
+    const longk = (KAABA_LNG * PI) / 180.0;
+    const phi = (latitude * PI) / 180.0;
+    const lambda = (longitude * PI) / 180.0;
+    return (
+        (180.0 / PI) *
+        Math.atan2(
+            Math.sin(longk - lambda),
+            Math.cos(phi) * Math.tan(latk) -
+                Math.sin(phi) * Math.cos(longk - lambda)
+        )
+    );
+};
+
+// Circular exponential smoothing so the needle eases instead of jumping. A factor
+// of 0 (or >= 1) disables smoothing and follows the raw reading.
+const smoothAngle = (previous, next, factor) => {
+    if (previous === null || factor <= 0 || factor >= 1) {
+        return next;
+    }
+    const diff = ((next - previous + 540) % 360) - 180;
+    return (previous + factor * diff + 360) % 360;
+};
+
+// Fire a success haptic if expo-haptics is installed. It is an optional peer
+// dependency, so this is a no-op when the host app doesn't provide it.
+const triggerHaptic = () => {
+    try {
+        // eslint-disable-next-line import/no-extraneous-dependencies, global-require
+        const Haptics = require('expo-haptics');
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    } catch {
+        // expo-haptics not available — skip.
+    }
+};
+
+export const useQiblaCompass = (options = {}) => {
+    const {
+        updateInterval = DEFAULT_UPDATE_INTERVAL,
+        smoothingFactor = DEFAULT_SMOOTHING,
+        alignTolerance = DEFAULT_ALIGN_TOLERANCE,
+    } = options;
+
     const [magnetometer, setMagnetometer] = useState(0);
     const [qiblad, setQiblad] = useState(0);
     const [error, setError] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
 
+    const subscriptionRef = useRef(null);
+    const smoothedRef = useRef(null);
+
+    const unsubscribe = useCallback(() => {
+        subscriptionRef.current?.remove();
+        subscriptionRef.current = null;
+    }, []);
+
+    const subscribe = useCallback(() => {
+        // Never stack listeners (e.g. across reinitCompass calls).
+        unsubscribe();
+        Magnetometer.setUpdateInterval(updateInterval);
+        subscriptionRef.current = Magnetometer.addListener((data) => {
+            const raw = computeAngle(data);
+            const next = smoothAngle(smoothedRef.current, raw, smoothingFactor);
+            smoothedRef.current = next;
+            setMagnetometer(Math.round(next));
+        });
+    }, [unsubscribe, updateInterval, smoothingFactor]);
+
     const initCompass = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+
         const isAvailable = await Magnetometer.isAvailableAsync();
         if (!isAvailable) {
             setError('Compass is not available on this device');
             setIsLoading(false);
             return;
         }
+
         const { status } = await Location.requestForegroundPermissionsAsync();
         if (status !== 'granted') {
             setError('Location permission not granted');
@@ -35,92 +150,30 @@ export const useQiblaCompass = () => {
         try {
             const location = await Location.getCurrentPositionAsync({});
             const { latitude, longitude } = location.coords;
-            calculate(latitude, longitude);
+            setQiblad(calculateQibla(latitude, longitude));
+        } catch {
+            setError('Could not determine your location');
         } finally {
             setIsLoading(false);
             subscribe();
         }
-    }, []);
+    }, [subscribe]);
 
     useEffect(() => {
         initCompass();
-
         return () => {
             unsubscribe();
         };
-    }, []);
+    }, [initCompass, unsubscribe]);
 
-    const subscribe = () => {
-        Magnetometer.setUpdateInterval(100);
-        setSubscription(
-            Magnetometer.addListener((data) => {
-                setMagnetometer(angle(data));
-            })
-        );
-    };
+    const compassDegree = headingFromAngle(magnetometer);
+    const compassDirection = cardinalDirection(compassDegree);
+    const compassRotate = 360 - compassDegree;
+    const kabaRotate = 360 - compassDegree + qiblad;
 
-    const unsubscribe = () => {
-        subscription && subscription.remove();
-        setSubscription(null);
-    };
-
-    const angle = (magnetometer) => {
-        let angle = 0;
-        if (magnetometer) {
-            const { x, y } = magnetometer;
-            if (Math.atan2(y, x) >= 0) {
-                angle = Math.atan2(y, x) * (180 / Math.PI);
-            } else {
-                angle = (Math.atan2(y, x) + 2 * Math.PI) * (180 / Math.PI);
-            }
-        }
-        return Math.round(angle);
-    };
-
-    const direction = (degree) => {
-        if (degree >= 22.5 && degree < 67.5) {
-            return 'NE';
-        } else if (degree >= 67.5 && degree < 112.5) {
-            return 'E';
-        } else if (degree >= 112.5 && degree < 157.5) {
-            return 'SE';
-        } else if (degree >= 157.5 && degree < 202.5) {
-            return 'S';
-        } else if (degree >= 202.5 && degree < 247.5) {
-            return 'SW';
-        } else if (degree >= 247.5 && degree < 292.5) {
-            return 'W';
-        } else if (degree >= 292.5 && degree < 337.5) {
-            return 'NW';
-        } else {
-            return 'N';
-        }
-    };
-
-    const degree = (magnetometer) => {
-        return magnetometer - 90 >= 0 ? magnetometer - 90 : magnetometer + 271;
-    };
-
-    const calculate = (latitude, longitude) => {
-        const PI = Math.PI;
-        const latk = (21.4225 * PI) / 180.0;
-        const longk = (39.8264 * PI) / 180.0;
-        const phi = (latitude * PI) / 180.0;
-        const lambda = (longitude * PI) / 180.0;
-        const qiblad =
-            (180.0 / PI) *
-            Math.atan2(
-                Math.sin(longk - lambda),
-                Math.cos(phi) * Math.tan(latk) -
-                Math.sin(phi) * Math.cos(longk - lambda)
-            );
-        setQiblad(qiblad);
-    };
-
-    const compassDirection = direction(degree(magnetometer));
-    const compassDegree = degree(magnetometer);
-    const compassRotate = 360 - degree(magnetometer);
-    const kabaRotate = 360 - degree(magnetometer) + qiblad;
+    const delta = ((kabaRotate % 360) + 360) % 360;
+    const isFacingQibla =
+        delta <= alignTolerance || delta >= 360 - alignTolerance;
 
     return {
         qiblad,
@@ -128,6 +181,7 @@ export const useQiblaCompass = () => {
         compassDegree,
         compassRotate,
         kabaRotate,
+        isFacingQibla,
         error,
         isLoading,
         reinitCompass: initCompass,
@@ -136,7 +190,20 @@ export const useQiblaCompass = () => {
 
 const QiblaCompass = forwardRef(
     (
-        { backgroundColor = 'transparent', color = '#000', textStyles = {}, compassImage, kaabaImage },
+        {
+            backgroundColor = 'transparent',
+            color = '#000',
+            textStyles = {},
+            compassImage,
+            kaabaImage,
+            size = DEFAULT_SIZE,
+            updateInterval = DEFAULT_UPDATE_INTERVAL,
+            smoothingFactor = DEFAULT_SMOOTHING,
+            alignTolerance = DEFAULT_ALIGN_TOLERANCE,
+            alignColor = DEFAULT_ALIGN_COLOR,
+            enableHaptics = false,
+            onAligned,
+        },
         ref
     ) => {
         const {
@@ -145,20 +212,37 @@ const QiblaCompass = forwardRef(
             compassDegree,
             compassRotate,
             kabaRotate,
+            isFacingQibla,
             error,
             isLoading,
             reinitCompass,
-        } = useQiblaCompass();
+        } = useQiblaCompass({
+            updateInterval,
+            smoothingFactor,
+            alignTolerance,
+        });
 
-        useImperativeHandle(
-            ref,
-            () => {
-                return {
-                    reinitCompass,
-                };
-            },
-            []
-        );
+        useImperativeHandle(ref, () => ({ reinitCompass }), [reinitCompass]);
+
+        // Fire onAligned (and an optional haptic) once each time the device starts
+        // facing the Qibla, not on every frame while aligned.
+        const wasFacingRef = useRef(false);
+        useEffect(() => {
+            if (isFacingQibla && !wasFacingRef.current) {
+                wasFacingRef.current = true;
+                if (onAligned) {
+                    onAligned();
+                }
+                if (enableHaptics) {
+                    triggerHaptic();
+                }
+            } else if (!isFacingQibla) {
+                wasFacingRef.current = false;
+            }
+        }, [isFacingQibla, enableHaptics, onAligned]);
+
+        const compassSize = moderateScale(size, 0.25);
+        const indicatorColor = isFacingQibla ? alignColor : color;
 
         if (isLoading) {
             return (
@@ -169,7 +253,18 @@ const QiblaCompass = forwardRef(
         }
 
         return (
-            <View style={[styles.container, { backgroundColor }]}>
+            <View
+                accessible
+                accessibilityRole="image"
+                accessibilityLabel={
+                    error
+                        ? `Qibla compass error: ${error}`
+                        : `Qibla compass. Heading ${compassDegree} degrees ${compassDirection}. ` +
+                          `Qibla at ${Math.round(qiblad)} degrees.` +
+                          (isFacingQibla ? ' Facing the Qibla.' : '')
+                }
+                style={[styles.container, { backgroundColor }]}
+            >
                 {error && (
                     <Text
                         style={{
@@ -199,7 +294,7 @@ const QiblaCompass = forwardRef(
                 <View
                     style={{
                         width: '100%',
-                        height: moderateScale(300, 0.25),
+                        height: compassSize,
                         position: 'relative',
                     }}
                 >
@@ -208,26 +303,20 @@ const QiblaCompass = forwardRef(
                         style={[
                             styles.image,
                             {
-                                transform: [
-                                    {
-                                        rotate: `${compassRotate}deg`,
-                                    },
-                                ],
+                                width: compassSize,
+                                height: compassSize,
+                                transform: [{ rotate: `${compassRotate}deg` }],
                                 zIndex: 100,
                             },
                         ]}
                     />
                     <View
                         style={{
-                            width: moderateScale(300, 0.25),
-                            height: moderateScale(300, 0.25),
+                            width: compassSize,
+                            height: compassSize,
                             position: 'absolute',
                             alignSelf: 'center',
-                            transform: [
-                                {
-                                    rotate: `${kabaRotate}deg`,
-                                },
-                            ],
+                            transform: [{ rotate: `${kabaRotate}deg` }],
                             flexDirection: 'row',
                             justifyContent: 'center',
                             zIndex: 999,
@@ -254,9 +343,12 @@ const QiblaCompass = forwardRef(
                         }}
                     />
                     <Text
-                        style={[styles.directionText, { color, ...textStyles }]}
+                        style={[
+                            styles.directionText,
+                            { color: indicatorColor, ...textStyles },
+                        ]}
                     >
-                        {qiblad.toFixed(2)}
+                        {qiblad.toFixed(2)}°
                     </Text>
                 </View>
             </View>
@@ -270,6 +362,13 @@ QiblaCompass.propTypes = {
     textStyles: PropTypes.object,
     compassImage: PropTypes.any,
     kaabaImage: PropTypes.any,
+    size: PropTypes.number,
+    updateInterval: PropTypes.number,
+    smoothingFactor: PropTypes.number,
+    alignTolerance: PropTypes.number,
+    alignColor: PropTypes.string,
+    enableHaptics: PropTypes.bool,
+    onAligned: PropTypes.func,
 };
 
 const styles = StyleSheet.create({
@@ -278,11 +377,8 @@ const styles = StyleSheet.create({
         alignSelf: 'center',
         position: 'absolute',
         top: 0,
-        width: moderateScale(300, 0.25),
-        height: moderateScale(300, 0.25),
     },
     container: {
-        backgroundColor: '#f00',
         justifyContent: 'center',
         alignItems: 'center',
         position: 'relative',
@@ -294,7 +390,6 @@ const styles = StyleSheet.create({
     directionText: {
         textAlign: 'center',
         fontSize: 30,
-        color: '#468773',
     },
     qiblaDirection: {
         flexDirection: 'row',

--- a/package.json
+++ b/package.json
@@ -1,46 +1,52 @@
 {
-  "name": "react-native-qibla-compass",
-  "version": "1.4.0",
-  "description": "Qibla Compass component and hook for React Native apps. Works with both Expo and React Native CLI projects.",
-  "main": "index.js",
-  "files": [
-    "index.js",
-    "assets/"
-  ],
-  "scripts": {
-    "lint": "eslint . --ext .js,.jsx --ignore-path .gitignore --fix --max-warnings 0"
-  },
-  "keywords": [
-    "qibla",
-    "compass",
-    "react-native",
-    "expo",
-    "islamic",
-    "prayer",
-    "mecca",
-    "kaaba",
-    "direction",
-    "magnetometer"
-  ],
-  "author": "Muhamed Muminovic",
-  "license": "ISC",
-  "dependencies": {
-    "prop-types": "^15.8.1",
-    "react-native-size-matters": "^0.4.0"
-  },
-  "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-native": ">=0.60.0",
-    "expo-location": ">=14.0.0",
-    "expo-sensors": ">=11.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mmuminovic/react-native-qibla-compass"
-  },
-  "devDependencies": {
-    "eslint": "^8.57.0",
-    "eslint-config-universe": "^12.0.0",
-    "prettier": "^3.2.5"
-  }
+    "name": "react-native-qibla-compass",
+    "version": "1.4.0",
+    "description": "Qibla Compass component and hook for React Native apps. Works with both Expo and React Native CLI projects.",
+    "main": "index.js",
+    "files": [
+        "index.js",
+        "assets/"
+    ],
+    "scripts": {
+        "lint": "eslint . --ext .js,.jsx --ignore-path .gitignore --fix --max-warnings 0"
+    },
+    "keywords": [
+        "qibla",
+        "compass",
+        "react-native",
+        "expo",
+        "islamic",
+        "prayer",
+        "mecca",
+        "kaaba",
+        "direction",
+        "magnetometer"
+    ],
+    "author": "Muhamed Muminovic",
+    "license": "ISC",
+    "dependencies": {
+        "prop-types": "^15.8.1",
+        "react-native-size-matters": "^0.4.0"
+    },
+    "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-native": ">=0.60.0",
+        "expo-location": ">=14.0.0",
+        "expo-sensors": ">=11.0.0",
+        "expo-haptics": ">=11.0.0"
+    },
+    "peerDependenciesMeta": {
+        "expo-haptics": {
+            "optional": true
+        }
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/mmuminovic/react-native-qibla-compass"
+    },
+    "devDependencies": {
+        "eslint": "^8.57.0",
+        "eslint-config-universe": "^12.0.0",
+        "prettier": "^3.2.5"
+    }
 }


### PR DESCRIPTION
Reliability fixes:
- Remove the magnetometer listener on unmount. It was leaking because the cleanup closed over the initial `subscription` state (always null); the subscription is now kept in a ref and removed correctly.
- reinitCompass no longer stacks magnetometer listeners (subscribe now removes any existing listener first).
- Catch errors from getCurrentPositionAsync in initCompass and surface them via `error` instead of silently swallowing them.
- Fix an off-by-one in the heading wrap (it used +271 instead of a proper modulo 360), which also returned 360 instead of 0 at the boundary.

Enhancements (all opt-in and fully backwards-compatible):
- Circular smoothing of the heading to reduce needle jitter (smoothingFactor).
- isFacingQibla flag plus an aligned color, an onAligned callback and optional haptics (expo-haptics declared as an optional peer dependency).
- New optional props: size, updateInterval, smoothingFactor, alignTolerance, alignColor, enableHaptics, onAligned.
- Accessibility label describing the current heading, direction and Qibla state.

Housekeeping:
- Add .gitignore (node_modules, lockfiles). This also makes `npm run lint` work, since the script reads ignores from .gitignore via --ignore-path.

Existing props, the hook signature and all previously returned values are unchanged, so current usage keeps working without modification.